### PR TITLE
Tiny speed up bundle install 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.0.0
   - 2.1.2
+bundler_args: --jobs=2
 services:
   - redis-server
 script: bundle exec rake spec


### PR DESCRIPTION
`bundle install` with `--jobs` option each travis build

via. http://docs.travis-ci.com/user/languages/ruby/#Speed-up-your-build-by-excluding-non-essential-dependencies
