### PR TITLE
Add redis requirement 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ barrage.next
 
 #### msec
 #### redis_worker_id
+requirement: redis 2.6+
+
 #### sequence
 
 ### Creating your own generator


### PR DESCRIPTION
script load is available since 2.6.0
- https://github.com/drecom/barrage/blob/29359d0c89d41acb5974f72a4043c88a9b8939c5/lib/barrage/generators/redis_worker_id.rb#L74
- http://redis.io/commands/script-load
