### PR TITLE
Fixed: fail bundle install when ruby 2.0 and 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,15 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in barrage.gemspec
 gemspec
+
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.2.2")
+  gem "activesupport", "< 5.0.0"
+end
+
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.2.3")
+  gem "listen", "< 3.1.0"
+end
+
+if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.2.5")
+  gem "ruby_dep", "< 1.4.0"
+end

--- a/barrage.gemspec
+++ b/barrage.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.0.0"
+  spec.add_development_dependency "rspec", "~> 3.5.0"
   spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "guard-rspec"


### PR DESCRIPTION
barrage supports ruby 2.0 and 2.1 on [.travis.yml](https://github.com/drecom/barrage/blob/d7121b7deef4a26ac8f1845cda379803d6717de1/.travis.yml), but `bundle install` is failure.

```
$ ruby -v
ruby 2.0.0p481 (2014-05-08 revision 45883) [x86_64-darwin14.5.0]

$ bundle install --path vendor/bundle
Fetching gem metadata from https://rubygems.org/.........
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies...
Using rake 12.0.0
Using concurrent-ruby 1.0.4
Using i18n 0.7.0
Using minitest 5.10.1
Using thread_safe 0.3.5
Using tzinfo 1.2.2
Installing activesupport 5.0.1

Gem::InstallError: activesupport requires Ruby version >= 2.2.2.
An error occurred while installing activesupport (5.0.1), and Bundler cannot continue.
Make sure that `gem install activesupport -v '5.0.1'` succeeds before bundling.
```