### PR TITLE
Fix redis client disconnect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,5 @@ end
 if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.2.5")
   gem "ruby_dep", "< 1.4.0"
 end
+
+gem "redis", ">= 4.0.0"

--- a/lib/barrage/generators/redis_worker_id.rb
+++ b/lib/barrage/generators/redis_worker_id.rb
@@ -50,7 +50,7 @@ class Barrage
 
           if redis.is_a?(Redis) and redis.connected?
             redis.del("barrage:worker:#{worker_id}") if real_ttl > Time.now.to_i
-            redis.client.disconnect
+            redis._client.disconnect
           end
         end
       end

--- a/spec/barrage/generators/redis_worker_id_spec.rb
+++ b/spec/barrage/generators/redis_worker_id_spec.rb
@@ -43,4 +43,24 @@ describe Barrage::Generators::RedisWorkerId do
       end
     end
   end
+
+  describe "#Finalizer" do
+    subject { described_class::Finalizer.new(data).call(*args) }
+
+    before do
+      redis._client.connect
+    end
+    let(:now) { Time.now.to_i }
+    let(:ttl) { 300 }
+    let(:redis) { Redis.new }
+    let(:worker_ttl) { now + ttl / 2 }
+    let(:real_ttl) { now + ttl }
+    let(:data) { [redis, worker_ttl, real_ttl] }
+    let(:args) { {} }
+
+    it "redis client disconnect" do
+      subject
+      expect(redis.connected?).to eq false
+    end
+  end
 end


### PR DESCRIPTION
### Summary
[redis 4.0 CHANGELOG.md](https://github.com/redis/redis-rb/blob/v4.6.0/CHANGELOG.md#40)
Added support for CLIENT commands. The lower-level client can be accessed via Redis#_client
