### PR TITLE
compatible with redis 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.2.0
+
+  * Compatible with Redis 5.0
+
 ## 0.1.1
 
   * Fix redis client disconnect

--- a/barrage.gemspec
+++ b/barrage.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport"
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.5.0"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "guard-rspec"

--- a/lib/barrage/version.rb
+++ b/lib/barrage/version.rb
@@ -1,3 +1,3 @@
 class Barrage
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
compatible with redis 5.0

Some methods were not supported in [redis 5.0](https://github.com/redis/redis-rb/blob/master/CHANGELOG.md), so I modified accordingly.