### PR TITLE
WIP: 単位時間を2倍(1/500[s])に変更

### DIFF
--- a/lib/barrage/generators/msec.rb
+++ b/lib/barrage/generators/msec.rb
@@ -6,7 +6,7 @@ class Barrage
       self.required_options += %w(start_at)
 
       def generate
-        ((Time.now.to_f * 1000).round - start_at) & (2 ** length - 1)
+        ((Time.now.to_f * 500).round - start_at) & (2 ** length - 1)
       end
 
       alias_method :current, :generate


### PR DESCRIPTION
master にマージしないため WIP です。

## 確認方法

```rb
require_relative 'lib/barrage.rb'

# (Time.mktime(2023, 2, 1).to_f * 500).round
start_at = 837588600000

b = Barrage.new("generators" => [{"name" => "msec", "length" => 39, "start_at" => start_at }, {"name" => "sequence", "length" => 25}])

# 基準にする ID
id1 = b.next
# 1秒待つ
sleep 1
# 1秒後の ID 採番
id2 = b.next
# ID の差分
p id2 - id1
```

## 確認結果

```
変更前
# msec が 1/1000[s] のときの1秒の id の進み
33587986433

変更後
# msec が 1/500[s] のときの1秒の id の進み
16777216001
```

変更前後で1秒で進む id がおよそ半分になっていることを確認しました。
